### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "guzzlehttp/guzzle": "~6.0",
-        "zendframework/zend-diactoros" : "1.*.*",
+        "zendframework/zend-diactoros" : "2.*.*",
         "symfony/psr-http-message-bridge" : "1.*.*"
     }
 }


### PR DESCRIPTION
this package is not maintainer for a long time, laravel 6.9 is out and some of the packages like laravel/password requires zendframework/zend-diactoros version 2 and above